### PR TITLE
Fixing entry point signature.

### DIFF
--- a/python/antiseptic/_lowlevel.pyi
+++ b/python/antiseptic/_lowlevel.pyi
@@ -1,6 +1,4 @@
-from typing import Literal
-
-def antiseptic(files: list[str], src: str) -> Literal[0, 1]:
+def antiseptic(files: list[str], src: str) -> int:
     """Performs a spell-check over the provided files.
 
     Args:


### PR DESCRIPTION
The Rust binary outputs 0 for no mistakes, 1 for spelling mistakes, and a greater positive number if Antiseptic failed to run correctly.