### PR TITLE
Bug fix for when exclude TOML value is not array.

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -33,7 +33,7 @@ fn get_exclude_array(
         if exclude_config_array_option.is_none() {
             println!(
                 "{}",
-                "Configuration setting \"config\" should be array.".red()
+                "Configuration setting \"exclude\" should be array.".red()
             );
             return Err(AntisepticError::IncorrectConfigTOMLType);
         }


### PR DESCRIPTION
The error message for when `exclude` is not an array has been changed from `Configuration setting "config" should be array.` to `Configuration setting "exclude" should be array.`.