### PR TITLE
Bug fix - now parsing `exclude` values correctly.

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -38,7 +38,14 @@ fn get_exclude_array(
             return Err(AntisepticError::IncorrectConfigTOMLType);
         }
         for exclude_value in exclude_config_array_option.unwrap() {
-            populate.push(exclude_value.to_string());
+            if !exclude_value.is_str() {
+                println!(
+                    "{}",
+                    "Configuration setting \"exclude\" should contain only strings.".red()
+                );
+                return Err(AntisepticError::IncorrectConfigTOMLType);
+            }
+            populate.push(exclude_value.as_str().unwrap().to_string());
         }
     }
 


### PR DESCRIPTION
Originally exclude values were incorrectly parsed, resulting in the quotation marks being included in the string. This didn't caues issues in forming globs, but is still a bad precedent for other future behaviour.