### PR TITLE
Allowing user-defined words to be permitted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ myfile.txt:15:32: AS001 spelling mistake `helol`
 
 Antiseptic is configured in `pyproject.toml`, `antiseptic.toml`, or `.antiseptic.toml`.
 
-At present there is only a single configuration setting, `exclude` which indicates directories and files which should not be included in the spell-check:
+There is a setting `exclude` which indicates directories and files which should not be included in the spell-check:
 
 ```toml
 exclude = [
@@ -47,5 +47,14 @@ exclude = [
     ".mypy_cache",
     ".ruff_cache",
     ".venv",
+]
+```
+
+There is also a setting `allowed-words` which defines words that Antiseptic will not flag:
+
+```toml
+allowed-words = [
+    "glubbage",
+    "glimp"
 ]
 ```

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -9,12 +9,14 @@ use crate::errors::all_errors::AntisepticError;
 pub struct Configuration {
     /// The list of globs needing to be excluded from Antiseptic's file search.
     pub exclude: Vec<String>,
+    pub allowed_words: Vec<String>,
 }
 
 impl Default for Configuration {
     fn default() -> Configuration {
         Configuration {
             exclude: Vec::new(),
+            allowed_words: Vec::new(),
         }
     }
 }
@@ -52,11 +54,45 @@ fn get_exclude_array(
     Ok(())
 }
 
+/// Obtains an array of all words which should be permitted by the spell-checker.
+///
+/// * `config_toml` - The TOML table containing Antiseptic's configuration.
+/// * `populate` - The vector of allowed words in memory.
+fn get_allowed_words_array(
+    config_toml: &Table,
+    populate: &mut Vec<String>,
+) -> Result<(), AntisepticError> {
+    let allowed_words_config_option = config_toml.get("allowed-words");
+    if allowed_words_config_option.is_some() {
+        let allowed_words_config_array_option = allowed_words_config_option.unwrap().as_array();
+        if allowed_words_config_array_option.is_none() {
+            println!(
+                "{}",
+                "Configuration setting \"allowed-words\" should be array.".red()
+            );
+            return Err(AntisepticError::IncorrectConfigTOMLType);
+        }
+        for allowed_words_value in allowed_words_config_array_option.unwrap() {
+            if !allowed_words_value.is_str() {
+                println!(
+                    "{}",
+                    "Configuration setting \"allowed-words\" should only contain strings.".red()
+                );
+                return Err(AntisepticError::IncorrectConfigTOMLType);
+            }
+            populate.push(allowed_words_value.as_str().unwrap().to_string());
+        }
+    }
+
+    Ok(())
+}
+
 /// Loads all the configuration TOML into a struct for later use.
 pub fn load_config(
     config_toml: &Table,
     configuration: &mut Configuration,
 ) -> Result<(), AntisepticError> {
     get_exclude_array(config_toml, configuration.exclude.borrow_mut())?;
+    get_allowed_words_array(config_toml, configuration.allowed_words.borrow_mut())?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,10 @@ fn antiseptic_main(
     find_files::collect_all_files(files, all_files.borrow_mut(), &configuration)?;
 
     // Obtains all words considered correct spellings.
-    let words_allowed: HashSet<String> = spellcheck::get_word_set(src_path)?;
+    let mut words_allowed: HashSet<String> = spellcheck::get_word_set(src_path)?;
+    for word in configuration.allowed_words {
+        words_allowed.insert(word);
+    }
 
     // Obtains all characters that are recognized as constituting a word, rather than punctuation.
     let characters_allowed: HashSet<char> = spellcheck::get_word_characters(src_path)?;


### PR DESCRIPTION
The user can defined an `allowed-words` array, and each word in the array, irrespective of whether or not it appears in a vocabulary dictionary, will not cause a spelling mistake when it appears in the repository.

Also adding new configuration to `README.md`.