### PR TITLE
Bug fix: Allowing all alphabetic characters.

### DIFF
--- a/src/spellcheck.rs
+++ b/src/spellcheck.rs
@@ -277,7 +277,7 @@ pub fn read_file(
         };
 
         // If the character can belong to a word, adds it to a token.
-        if characters_allowed.contains(&character) {
+        if character.is_alphabetic() || characters_allowed.contains(&character) {
             token.push(character);
         }
         // If the character is whitespace/punctuation, and a token has already started to be formed,


### PR DESCRIPTION
Previously, if a UTF-8 character not in the dictionary were used in a word, the word would be divided by that character incorrectly. Now the whole word will be considered as a single word.